### PR TITLE
Utilise GITHUB_TOKEN to commit to gh-pages and deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,10 @@ jobs:
     - name: Generate report
       run: bash ./run.sh
     - name: Deploy GitHub pages
-      run: |
-        export TOKEN=${{ secrets.ACCESS_TOKEN }}
-        export DEPLOY_KEY=${{ secrets.DEPLOY_KEY }}
-        source ./configs/github.sh
-        source ./configs/deploy.sh
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./reposense-report
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
+        commit_message: Rebuild pages at 


### PR DESCRIPTION
Part of https://github.com/reposense/RepoSense/issues/1448.

Test action flow: https://github.com/dcshzj/publish-RepoSense/actions/runs/629123865
Generated report: https://dcshzj.github.io/publish-RepoSense/ (uses default values of this repository)

```
Users need to specify a personal access token or a deploy key to
automate the generation of the RepoSense report. This is an
additional step that makes using this repository less
user-friendly for new users.

Let's make use of the autogenerated GITHUB_TOKEN when using
GitHub Actions to automatically push to the gh-pages branch and to
trigger a GitHub Pages build.
```