### PR TITLE
Support using RepoSense of a specific commit

### DIFF
--- a/get-reposense.py
+++ b/get-reposense.py
@@ -11,39 +11,51 @@ JAR_FILENAME = 'RepoSense.jar'
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Downloads a specific version of RepoSense.jar from our repository.')
-    
+
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-r', '--release', action='store_true', help='Get RepoSense.jar from the latest release (Stable)')
     group.add_argument('-m', '--master', action='store_true', help='Get RepoSense.jar from the latest master (Beta)')
     group.add_argument('-t', '--tag', help='Get RepoSense.jar of a specific release version tag')
+    group.add_argument('-c', '--commit', help='Get RepoSense.jar of a specific commit')
 
     parser.add_argument('-o', '--overwrite', action='store_true', help='Overwrite RepoSense.jar file, if exists. Default: false')
 
     return parser.parse_args()
 
+def handle_specific_commit(commit):
+    get_reposense_jar('https://api.github.com/repos/reposense/RepoSense/commits/' + commit, commit=commit)
+
 def handle_specific_release(tag):
-    get_reposense_jar('https://api.github.com/repos/reposense/RepoSense/releases/tags/' + tag, tag)
+    get_reposense_jar('https://api.github.com/repos/reposense/RepoSense/releases/tags/' + tag, tag=tag)
 
 def handle_latest_release():
     get_reposense_jar('https://api.github.com/repos/reposense/RepoSense/releases/latest')
 
-def get_reposense_jar(url, tag=None):
+def get_reposense_jar(url, tag=None, commit=None):
     response = requests.get(url)
 
     if tag and response.status_code == 404:
-        print('Error, tag does not exists!')
+        print('Error, the provided tag does not exist!')
         exit(1)
 
-    if response.status_code == 403:
+    if commit and response.status_code in [404, 422]:
+        print('Error, the provided commit does not exist!')
+        exit(1)
+
+    if response.status_code in [403, 500]:
         print('GitHub API has exceed the rate limit. Falling back to alternative method...')
-        clone_and_make_reposense(tag)
+        clone_and_make_reposense(tag=tag, commit=commit)
+        return
+
+    if commit:
+        clone_and_make_reposense(commit=commit)
         return
 
     url = response.json()['assets'][0]['browser_download_url']
     download_file(url)
 
-def clone_and_make_reposense(tag=None):
-    
+def clone_and_make_reposense(tag=None, commit=None):
+
     # Cleanup cached RepoSense folder
     shutil.rmtree('RepoSense', ignore_errors=True)
 
@@ -55,13 +67,15 @@ def clone_and_make_reposense(tag=None):
 
     if tag:
         command += 'git checkout tags/{} -b deploy &&'.format(tag)
+    elif commit:
+        command +=  'git checkout {} -b deploy &&'.format(commit)
 
     command += \
     '''
     ./gradlew zipreport shadowjar &&
     mv build/jar/RepoSense.jar ../
     '''
-   
+
     subprocess.check_call(command, shell=True)
 
 def download_file(url):
@@ -70,7 +84,7 @@ def download_file(url):
 
 if __name__ == "__main__":
     args = parse_args()
-    
+
     if os.path.exists(JAR_FILENAME) and args.overwrite is False:
         print(JAR_FILENAME + ' already exists. Quitting.')
         exit()
@@ -78,7 +92,11 @@ if __name__ == "__main__":
     if args.tag:
         handle_specific_release(args.tag)
         exit()
-    
+
+    if args.commit:
+        handle_specific_commit(args.commit)
+        exit()
+
     if args.master:
         clone_and_make_reposense()
         exit()

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,9 @@
 # Downloads a specific version of RepoSense.jar of your choice from our repository
 ## Examples of supported options:
 ### ./get-reposense.py --release               # Gets the latest release (Stable)
-### ./get-reposense.py --master                # Gets the latest master  (Beta)
+### ./get-reposense.py --master                # Gets the latest master (Beta)
 ### ./get-reposense.py --tag v1.6.1            # Gets a specific version
+### ./get-reposense.py --commit abc123         # Gets a specific commit
 ### ./get-reposense.py --release --overwrite   # Overwrite RepoSense.jar, if exists, with the latest release
 
 ./get-reposense.py --release


### PR DESCRIPTION
Part of https://github.com/reposense/RepoSense/issues/1515.

Sample run: https://github.com/dcshzj/publish-RepoSense/runs/2235851498?check_suite_focus=true (uses [`5f0dff261de89c7c056e54b5ef7443e773bfa73e`](https://github.com/reposense/RepoSense/commit/5f0dff261de89c7c056e54b5ef7443e773bfa73e))
Preview website: https://dcshzj.github.io/publish-RepoSense/

```
The script to obtain RepoSense does not support a way to use
RepoSense at a specific commit.

Let's add the functionality to checkout a specific commit and
build RepoSense using that commit..
```