### PR TITLE
[#2258] Update Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = """
+  wget https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz &&
+  tar -xvzf openjdk-11_linux-x64_bin.tar.gz &&
+  mv jdk-11 ~/openjdk11 &&
+  export JAVA_HOME=$HOME/openjdk11 &&
+  export PATH=$JAVA_HOME/bin:$PATH &&
+  pip install requests && ./run.sh
+  """
+
+  publish = "./reposense-report"
+  base = "./"


### PR DESCRIPTION
Fix https://github.com/reposense/RepoSense/issues/2258

# Proposed commit message
```
Update build and deploy script for Netlify

The current instructions to deploy to Netlify no longer work as the
default build image only has Java 8.

Let's add code to manually set up Java 11 on Netlify for deployment.

```
# Other information
Attempt to manually set up Java 11 environment on Netlify deployment server.
This is the [test website](https://gilded-druid-5c5802.netlify.app/?search=&sort=groupTitle%20dsc&sortWithin=title&timeframe=commit&mergegroup=&groupSelect=groupByRepos&breakdown=false) and [its build and deployment logs](https://app.netlify.com/sites/gilded-druid-5c5802/deploys/679c3cb220cfbf00088a5d8f)