### PR TITLE
[#2252] Update ubuntu runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: pip install requests
     - name: Generate report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '11'
     
     - name: Install dependencies
       run: pip install requests


### PR DESCRIPTION
Part of #2252 in [Reposense Repository](https://github.com/reposense/RepoSense/issues/2252)

### Proposed commit message

```
Update ubuntu runner to ubuntu-24.04

This PR updates the CI configuration to ubuntu 24.04 as the runner.
This ensures that our code is tested on the latest Ubuntu version,
providing better compatibility and early detection of potential issues. 
```