### PR TITLE
[#2316] Update CI/CD Trigger to Allow Automatic Execution for All Relevant Events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,8 @@ jobs:
         echo "VITE_BASE_DIR: $VITE_BASE_DIR"
         ./run.sh
 
-    - name: Deploy GitHub pages
+    - name: Deploy GitHub page
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master's
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: pip install requests
     - name: Generate report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,14 @@ on:
   pull_request:
   push:
     branches:
-      - '**'
+      - master
+  # For scheduled deployment with Cron Jobs.
+  ## Examples of cron schedule expressions:
+  ### '0 * * * *': hourly
+  ### '0 0 * * *': daily
+  ### '0 0 1 * *': monthly
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -38,7 +45,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '11'
     
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,6 @@ on:
   push:
     branches:
       - master
-# For scheduled deployment with Cron Jobs.
-## Examples of cron schedule expressions:
-### '0 * * * *': hourly
-### '0 0 * * *': daily
-### '0 0 1 * *': monthly
-#   schedule:
-#     - cron:  '0 0 * * *'
 
 jobs:
   build:
@@ -36,7 +29,6 @@ jobs:
         ./run.sh
 
     - name: Deploy GitHub pages
-      if : github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
   ### '0 * * * *': hourly
   ### '0 0 * * *': daily
   ### '0 0 1 * *': monthly
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+  ##  - cron: '0 0 * * *'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         ./run.sh
 
     - name: Deploy GitHub page
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master's
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - '**'
 
 jobs:
   build:
@@ -28,12 +28,32 @@ jobs:
         echo "VITE_BASE_DIR: $VITE_BASE_DIR"
         ./run.sh
 
-    - name: Deploy GitHub page
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./reposense-report
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Rebuild pages at
+        name: reposense-report
+        path: ./reposense-report
+
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: reposense-report
+          path: ./reposense-report
+
+      - name: Deploy GitHub pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./reposense-report
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: Rebuild pages at


### PR DESCRIPTION
Fixes [#2316](https://github.com/reposense/RepoSense/issues/2316) from [RepoSense](https://github.com/reposense/RepoSense/issues)

Proposed commit message
```
Update CI/CD Trigger Condition to Allow Execution for All Events

The current CI/CD trigger condition restricts execution to pushes 
on the master branch.
Update the condition to allow the pipeline to run automatically for 
all relevant events.
```